### PR TITLE
Forced export (with extra fixes)

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1843,7 +1843,7 @@ zpool_do_destroy(int argc, char **argv)
 		return (1);
 	}
 
-	if (zpool_disable_datasets(zhp, force) != 0) {
+	if (zpool_disable_datasets(zhp, force, FALSE) != 0) {
 		(void) fprintf(stderr, gettext("could not destroy '%s': "
 		    "could not unmount datasets\n"), zpool_get_name(zhp));
 		zpool_close(zhp);
@@ -1873,7 +1873,7 @@ zpool_export_one(zpool_handle_t *zhp, void *data)
 {
 	export_cbdata_t *cb = data;
 
-	if (zpool_disable_datasets(zhp, cb->force || cb->hardforce) != 0)
+	if (zpool_disable_datasets(zhp, cb->force, cb->hardforce) != 0)
 		return (1);
 
 	/* The history must be logged as part of the export */

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -924,8 +924,16 @@ int zfs_smb_acl_rename(libzfs_handle_t *, char *, char *, char *, char *);
  * Enable and disable datasets within a pool by mounting/unmounting and
  * sharing/unsharing them.
  */
-extern int zpool_enable_datasets(zpool_handle_t *, const char *, int);
-extern int zpool_disable_datasets(zpool_handle_t *, boolean_t);
+_LIBZFS_H int zpool_enable_datasets(zpool_handle_t *, const char *, int);
+_LIBZFS_H int zpool_disable_datasets(zpool_handle_t *, boolean_t, boolean_t);
+_LIBZFS_H void zpool_disable_datasets_os(zpool_handle_t *, boolean_t);
+_LIBZFS_H void zpool_disable_volume_os(const char *);
+
+/*
+ * Procedure to inform os that we have started force unmount (linux specific).
+ */
+_LIBZFS_H void zpool_unmount_mark_hard_force_begin(zpool_handle_t *zhp);
+_LIBZFS_H void zpool_unmount_mark_hard_force_end(zpool_handle_t *zhp);
 
 /*
  * Parse a features file for -o compatibility

--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -134,6 +134,8 @@ extern minor_t zfsdev_minor_alloc(void);
 /* Called on entry to each ZFS vnode and vfs operation  */
 #define	ZFS_ENTER(zfsvfs)	ZFS_ENTER_ERROR(zfsvfs, EIO)
 
+#define	ZFS_ENTER_UNMOUNTOK	ZFS_ENTER
+
 /* Must be called before exiting the vop */
 #define	ZFS_EXIT(zfsvfs)	ZFS_TEARDOWN_EXIT_READ(zfsvfs, FTAG)
 

--- a/include/os/linux/spl/sys/thread.h
+++ b/include/os/linux/spl/sys/thread.h
@@ -56,7 +56,7 @@ typedef void (*thread_func_t)(void *);
 /* END CSTYLED */
 
 #define	thread_signal(t, s)		spl_kthread_signal(t, s)
-#define	thread_exit()			__thread_exit()
+#define	thread_exit()			spl_thread_exit()
 #define	thread_join(t)			VERIFY(0)
 #define	curthread			current
 #define	getcomm()			current->comm
@@ -69,6 +69,13 @@ extern void __thread_exit(void);
 extern struct task_struct *spl_kthread_create(int (*func)(void *),
     void *data, const char namefmt[], ...);
 extern int spl_kthread_signal(kthread_t *tsk, int sig);
+
+static inline __attribute__((noreturn)) void
+spl_thread_exit(void)
+{
+	tsd_exit();
+	SPL_KTHREAD_COMPLETE_AND_EXIT(NULL, 0);
+}
 
 extern proc_t p0;
 

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -594,7 +594,7 @@ void dmu_buf_add_ref(dmu_buf_t *db, void* tag);
 boolean_t dmu_buf_try_add_ref(dmu_buf_t *, objset_t *os, uint64_t object,
     uint64_t blkid, void *tag);
 
-void dmu_buf_rele(dmu_buf_t *db, void *tag);
+void dmu_buf_rele(dmu_buf_t *db, const void *tag);
 uint64_t dmu_buf_refcount(dmu_buf_t *db);
 uint64_t dmu_buf_user_refcount(dmu_buf_t *db);
 

--- a/include/sys/dmu_recv.h
+++ b/include/sys/dmu_recv.h
@@ -35,7 +35,7 @@
 #include <sys/spa.h>
 #include <sys/objlist.h>
 
-extern const char *recv_clone_name;
+extern const char *const recv_clone_name;
 
 typedef struct dmu_recv_cookie {
 	struct dsl_dataset *drc_ds;

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -243,7 +243,7 @@ typedef struct dsl_dataset {
 	kmutex_t ds_sendstream_lock;
 	list_t ds_sendstreams;
 
-	void *ds_receiver;	/* really a dmu_recv_cookie_t */
+	struct dmu_recv_cookie *ds_receiver;
 
 	/*
 	 * When in the middle of a resumable receive, tracks how much
@@ -331,10 +331,10 @@ boolean_t dsl_dataset_try_add_ref(struct dsl_pool *dp, dsl_dataset_t *ds,
     void *tag);
 int dsl_dataset_create_key_mapping(dsl_dataset_t *ds);
 int dsl_dataset_hold_obj_flags(struct dsl_pool *dp, uint64_t dsobj,
-    ds_hold_flags_t flags, void *tag, dsl_dataset_t **);
+    ds_hold_flags_t flags, const void *tag, dsl_dataset_t **);
 void dsl_dataset_remove_key_mapping(dsl_dataset_t *ds);
 int dsl_dataset_hold_obj(struct dsl_pool *dp, uint64_t dsobj,
-    void *tag, dsl_dataset_t **);
+    const void *tag, dsl_dataset_t **);
 void dsl_dataset_rele_flags(dsl_dataset_t *ds, ds_hold_flags_t flags,
     void *tag);
 void dsl_dataset_rele(dsl_dataset_t *ds, void *tag);

--- a/include/sys/dsl_scan.h
+++ b/include/sys/dsl_scan.h
@@ -171,8 +171,12 @@ int dsl_scan_cancel(struct dsl_pool *);
 int dsl_scan(struct dsl_pool *, pool_scan_func_t);
 void dsl_scan_assess_vdev(struct dsl_pool *dp, vdev_t *vd);
 boolean_t dsl_scan_scrubbing(const struct dsl_pool *dp);
-int dsl_scrub_set_pause_resume(const struct dsl_pool *dp, pool_scrub_cmd_t cmd);
-int dsl_scan_restart_resilver(struct dsl_pool *, uint64_t txg);
+boolean_t dsl_errorscrubbing(const struct dsl_pool *dp);
+boolean_t dsl_errorscrub_active(dsl_scan_t *scn);
+int dsl_scan_restart_resilver(struct dsl_pool *dp, uint64_t txg);
+int dsl_scrub_set_pause_resume(const struct dsl_pool *dp,
+    pool_scrub_cmd_t cmd);
+void dsl_errorscrub_sync(struct dsl_pool *, dmu_tx_t *);
 boolean_t dsl_scan_resilvering(struct dsl_pool *dp);
 boolean_t dsl_scan_resilver_scheduled(struct dsl_pool *dp);
 boolean_t dsl_dataset_unstable(struct dsl_dataset *ds);

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1380,6 +1380,8 @@ typedef enum zfs_ioc {
 	ZFS_IOC_UNJAIL,				/* 0x86 (FreeBSD) */
 	ZFS_IOC_SET_BOOTENV,			/* 0x87 */
 	ZFS_IOC_GET_BOOTENV,			/* 0x88 */
+	ZFS_IOC_HARD_FORCE_UNMOUNT_BEGIN,	/* 0x89 (Linux) */
+	ZFS_IOC_HARD_FORCE_UNMOUNT_END,		/* 0x8a (Linux) */
 	ZFS_IOC_LAST
 } zfs_ioc_t;
 

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -753,6 +753,7 @@ extern int spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 extern int spa_import(char *pool, nvlist_t *config, nvlist_t *props,
     uint64_t flags);
 extern nvlist_t *spa_tryimport(nvlist_t *tryconfig);
+extern int spa_set_pre_export_status(const char *pool, boolean_t status);
 extern int spa_destroy(const char *pool);
 extern int spa_checkpoint(const char *pool);
 extern int spa_checkpoint_discard(const char *pool);
@@ -957,10 +958,12 @@ extern void spa_iostats_trim_add(spa_t *spa, trim_type_t type,
     uint64_t extents_skipped, uint64_t bytes_skipped,
     uint64_t extents_failed, uint64_t bytes_failed);
 
-/* Config lock handling flags */
 typedef enum {
+	/* Config lock handling flags */
 	SCL_FLAG_TRYENTER	= 1U << 0,
 	SCL_FLAG_NOSUSPEND	= 1U << 1,
+	/* MMP flag */
+	SCL_FLAG_MMP		= 1U << 2,
 } spa_config_flag_t;
 
 extern void spa_import_progress_add(spa_t *spa);
@@ -973,7 +976,8 @@ extern int spa_import_progress_set_state(uint64_t pool_guid,
     spa_load_state_t spa_load_state);
 
 /* Pool configuration locks */
-extern int spa_config_tryenter(spa_t *spa, int locks, void *tag, krw_t rw);
+extern int spa_config_tryenter(spa_t *spa, int locks, const void *tag,
+    krw_t rw);
 extern int spa_config_enter_flags(spa_t *spa, int locks, const void *tag,
     krw_t rw, spa_config_flag_t flags);
 extern void spa_config_enter(spa_t *spa, int locks, const void *tag, krw_t rw);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -245,6 +245,7 @@ struct spa {
 	list_t		spa_evicting_os_list;	/* Objsets being evicted. */
 	kcondvar_t	spa_evicting_os_cv;	/* Objset Eviction Completion */
 	kthread_t	*spa_export_initiator;	/* thread exporting the pool */
+	boolean_t	spa_pre_exporting;	/* allow fails before export */
 	txg_list_t	spa_vdev_txg_list;	/* per-txg dirty vdev list */
 	vdev_t		*spa_root_vdev;		/* top-level vdev container */
 	uint64_t	spa_min_ashift;		/* of vdevs in normal class */

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -233,7 +233,7 @@ typedef pthread_t	kthread_t;
 	zk_thread_create(func, arg, stksize, state)
 #define	thread_create(stk, stksize, func, arg, len, pp, state, pri)	\
 	zk_thread_create(func, arg, stksize, state)
-#define	thread_signal(t, s) pthread_kill((pthread_t)t, s)
+#define	thread_signal(t, s) pthread_kill((pthread_t)(t), s)
 #define	thread_exit()	pthread_exit(NULL)
 #define	thread_join(t)	pthread_join((pthread_t)(t), NULL)
 

--- a/include/sys/zfs_ioctl_impl.h
+++ b/include/sys/zfs_ioctl_impl.h
@@ -74,6 +74,10 @@ typedef struct zfs_ioc_key {
 
 int zfs_secpolicy_config(zfs_cmd_t *, nvlist_t *, cred_t *);
 
+void zfs_ioctl_register_pool(zfs_ioc_t ioc, zfs_ioc_legacy_func_t *func,
+    zfs_secpolicy_func_t *secpolicy, boolean_t log_history,
+    zfs_ioc_poolcheck_t pool_check);
+
 void zfs_ioctl_register_dataset_nolog(zfs_ioc_t, zfs_ioc_legacy_func_t *,
     zfs_secpolicy_func_t *, zfs_ioc_poolcheck_t);
 

--- a/include/sys/zfs_znode.h
+++ b/include/sys/zfs_znode.h
@@ -215,6 +215,43 @@ typedef struct znode {
 	ZNODE_OS_FIELDS;
 } znode_t;
 
+/* Verifies the znode is valid. */
+static inline int
+zfs_verify_zp(znode_t *zp)
+{
+	if (unlikely(zp->z_sa_hdl == NULL))
+		return (SET_ERROR(EIO));
+	return (0);
+}
+
+/* zfs_enter and zfs_verify_zp together */
+static inline int
+zfs_enter_verify_zp(zfsvfs_t *zfsvfs, znode_t *zp, const char *tag)
+{
+	int error;
+
+	ZFS_ENTER(zfsvfs);
+	if ((error = zfs_verify_zp(zp)) != 0) {
+		ZFS_EXIT(zfsvfs);
+		return (error);
+	}
+	return (0);
+}
+
+/* zfs_enter_unmountok and zfs_verify_zp together */
+static inline int
+zfs_enter_unmountok_verify_zp(zfsvfs_t *zfsvfs, znode_t *zp, const char *tag)
+{
+	int error;
+
+	ZFS_ENTER_UNMOUNTOK(zfsvfs);
+	if ((error = zfs_verify_zp(zp)) != 0) {
+		ZFS_EXIT(zfsvfs);
+		return (error);
+	}
+	return (0);
+}
+
 typedef struct znode_hold {
 	uint64_t	zh_obj;		/* object id */
 	avl_node_t	zh_node;	/* avl tree linkage */

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -488,7 +488,6 @@ make_dataset_handle(libzfs_handle_t *hdl, const char *path)
 
 	zhp->zfs_hdl = hdl;
 	(void) strlcpy(zhp->zfs_name, path, sizeof (zhp->zfs_name));
-
 	if (!hdl->libzfs_force_export) {
 		zfs_cmd_t zc = {"\0"};
 

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1525,7 +1525,8 @@ mountpoint_compare(const void *a, const void *b)
  * and gather all the filesystems that are currently mounted.
  */
 int
-zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
+zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force,
+    boolean_t hardforce)
 {
 	int used, alloc;
 	struct mnttab entry;
@@ -1535,9 +1536,9 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	int i;
 	int ret = -1;
-	int flags = (force ? MS_FORCE : 0);
+	int flags = ((hardforce || force) ? MS_FORCE : 0);
 
-	hdl->libzfs_force_export = force;
+	hdl->libzfs_force_export = flags & MS_FORCE;
 	namelen = strlen(zhp->zpool_name);
 
 	/* Reopen MNTTAB to prevent reading stale data from open file */
@@ -1616,6 +1617,10 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	 */
 	qsort(mountpoints, used, sizeof (char *), mountpoint_compare);
 
+	if (hardforce) {
+		zpool_unmount_mark_hard_force_begin(zhp);
+	}
+
 	/*
 	 * Walk through and first unshare everything.
 	 */
@@ -1660,6 +1665,9 @@ out:
 	}
 	free(datasets);
 	free(mountpoints);
+	if (ret != 0 && hardforce) {
+		zpool_unmount_mark_hard_force_end(zhp);
+	}
 
 	return (ret);
 }

--- a/lib/libzfs/os/freebsd/libzfs_zmount.c
+++ b/lib/libzfs/os/freebsd/libzfs_zmount.c
@@ -133,3 +133,29 @@ zfs_mount_delegation_check(void)
 {
 	return (0);
 }
+
+/* Called from the tail end of zpool_disable_datasets() */
+void
+zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force)
+{
+	(void) zhp, (void) force;
+}
+
+/* Called from the tail end of zfs_unmount() */
+void
+zpool_disable_volume_os(const char *name)
+{
+	(void) name;
+}
+
+void
+zpool_unmount_mark_hard_force_begin(zpool_handle_t *zhp)
+{
+	(void) zhp;
+}
+
+void
+zpool_unmount_mark_hard_force_end(zpool_handle_t *zhp)
+{
+	(void) zhp;
+}

--- a/lib/libzfs/os/linux/libzfs_mount_os.c
+++ b/lib/libzfs/os/linux/libzfs_mount_os.c
@@ -411,3 +411,37 @@ zfs_mount_delegation_check(void)
 {
 	return ((geteuid() != 0) ? EACCES : 0);
 }
+
+/* Called from the tail end of zpool_disable_datasets() */
+void
+zpool_disable_datasets_os(zpool_handle_t *zhp, boolean_t force)
+{
+	(void) zhp, (void) force;
+}
+
+/* Called from the tail end of zfs_unmount() */
+void
+zpool_disable_volume_os(const char *name)
+{
+	(void) name;
+}
+
+void
+zpool_unmount_mark_hard_force_begin(zpool_handle_t *zhp)
+{
+	zfs_cmd_t zc = {"\0"};
+	libzfs_handle_t *hdl = zhp->zpool_hdl;
+
+	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+	(void) zfs_ioctl(hdl, ZFS_IOC_HARD_FORCE_UNMOUNT_BEGIN, &zc);
+}
+
+void
+zpool_unmount_mark_hard_force_end(zpool_handle_t *zhp)
+{
+	zfs_cmd_t zc = {"\0"};
+	libzfs_handle_t *hdl = zhp->zpool_hdl;
+
+	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+	(void) zfs_ioctl(hdl, ZFS_IOC_HARD_FORCE_UNMOUNT_END, &zc);
+}

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -966,6 +966,18 @@ receive of encrypted datasets.
 Intended for users whose pools were created with
 OpenZFS pre-release versions and now have compatibility issues.
 .
+.It Sy zfs_forced_export_unmount_enabled Ns = Ns Sy 0 Ns | Ns 1 Pq int
+During forced unmount, leave the filesystem in a disabled mode of operation,
+in which all new I/Os fail, except for those required to unmount it.
+Intended for users trying to forcibly export a pool even when I/Os are in
+progress, without the need to find and stop them.
+This option does not affect processes that are merely sitting on the
+filesystem, only those performing active I/O.
+.Pp
+This parameter can be set to 1 to enable this behavior.
+.Pp
+This parameter only applies on Linux.
+.
 .It Sy zfs_key_max_salt_uses Ns = Ns Sy 400000000 Po 4*10^8 Pc Pq ulong
 Maximum number of uses of a single salt value before generating a new one for
 encrypted datasets.

--- a/man/man8/zpool-export.8
+++ b/man/man8/zpool-export.8
@@ -26,7 +26,7 @@
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
 .\"
-.Dd February 16, 2020
+.Dd November 1, 2022
 .Dt ZPOOL-EXPORT 8
 .Os
 .
@@ -37,6 +37,7 @@
 .Nm zpool
 .Cm export
 .Op Fl f
+.Op Fl F
 .Fl a Ns | Ns Ar pool Ns …
 .
 .Sh DESCRIPTION
@@ -73,7 +74,7 @@ This option allows a pool to be exported even when the underlying disks are
 offline and the pool is unavailable.
 When force exporting a pool, any outstanding dirty data will be discarded.
 This option implies the
-.It Fl f
+.Fl f
 option.
 .El
 .

--- a/module/os/linux/spl/spl-thread.c
+++ b/module/os/linux/spl/spl-thread.c
@@ -224,4 +224,5 @@ spl_kthread_signal(kthread_t *tsk, int sig)
 
 	return (send_sig(sig, tsk, 0));
 }
+
 EXPORT_SYMBOL(spl_kthread_signal);

--- a/module/os/linux/zfs/zfs_ioctl_os.c
+++ b/module/os/linux/zfs/zfs_ioctl_os.c
@@ -218,9 +218,28 @@ zfs_ioctl_update_mount_cache(const char *dsname)
 {
 }
 
+static int
+zfs_ioc_pool_unmount_begin(zfs_cmd_t *zc)
+{
+	return (spa_set_pre_export_status(zc->zc_name, true));
+}
+
+static int
+zfs_ioc_pool_unmount_end(zfs_cmd_t *zc)
+{
+	return (spa_set_pre_export_status(zc->zc_name, false));
+}
+
 void
 zfs_ioctl_init_os(void)
 {
+
+	zfs_ioctl_register_pool(ZFS_IOC_HARD_FORCE_UNMOUNT_BEGIN,
+	    zfs_ioc_pool_unmount_begin, zfs_secpolicy_config, B_FALSE,
+	    POOL_CHECK_NONE);
+	zfs_ioctl_register_pool(ZFS_IOC_HARD_FORCE_UNMOUNT_END,
+	    zfs_ioc_pool_unmount_end, zfs_secpolicy_config, B_FALSE,
+	    POOL_CHECK_NONE);
 }
 
 #ifdef CONFIG_COMPAT

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -275,7 +275,11 @@ zfs_sync(struct super_block *sb, int wait, cred_t *cr)
 		 */
 		dsl_pool_t *dp;
 
-		ZFS_ENTER(zfsvfs);
+		/*
+		 * If the dataset has been unmounted, return success. We might
+		 * be force-exporting, and we don't want to start a flush if so.
+		 */
+		ZFS_ENTER_UNMOUNTOK(zfsvfs);
 		dp = dmu_objset_pool(zfsvfs->z_os);
 
 		/*
@@ -1156,7 +1160,7 @@ zfs_statvfs(struct inode *ip, struct kstatfs *statp)
 	}
 
 	ZFS_EXIT(zfsvfs);
-	return (err);
+	return(err);
 }
 
 static int

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -213,7 +213,8 @@ zpl_remount_fs(struct super_block *sb, int *flags, char *data)
 static int
 __zpl_show_devname(struct seq_file *seq, zfsvfs_t *zfsvfs)
 {
-	ZPL_ENTER_UNMOUNTOK(zfsvfs);
+
+	ZFS_ENTER_UNMOUNTOK(zfsvfs);
 
 	char *fsname = kmem_alloc(ZFS_MAX_DATASET_NAME_LEN, KM_SLEEP);
 	dmu_objset_name(zfsvfs->z_os, fsname);

--- a/module/zfs/dmu_tx.c
+++ b/module/zfs/dmu_tx.c
@@ -1094,7 +1094,8 @@ dmu_tx_assign(dmu_tx_t *tx, uint64_t txg_how)
 		if (err != ERESTART || !(txg_how & TXG_WAIT))
 			return (err);
 
-		dmu_tx_wait_flags(tx, txg_how);
+		dmu_tx_wait_flags(tx,
+		    (txg_how & TXG_NOSUSPEND) ? TXG_WAIT_F_NOSUSPEND : 0);
 	}
 
 	txg_rele_to_quiesce(&tx->tx_txgh);

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -561,7 +561,7 @@ dsl_dataset_try_add_ref(dsl_pool_t *dp, dsl_dataset_t *ds, void *tag)
 
 int
 dsl_dataset_hold_obj_flags(dsl_pool_t *dp, uint64_t dsobj,
-    ds_hold_flags_t flags, void *tag, dsl_dataset_t **dsp)
+    ds_hold_flags_t flags, const void *tag, dsl_dataset_t **dsp)
 {
 	objset_t *mos = dp->dp_meta_objset;
 	dmu_buf_t *dbuf;
@@ -762,7 +762,7 @@ dsl_dataset_create_key_mapping(dsl_dataset_t *ds)
 }
 
 int
-dsl_dataset_hold_obj(dsl_pool_t *dp, uint64_t dsobj, void *tag,
+dsl_dataset_hold_obj(dsl_pool_t *dp, uint64_t dsobj, const void *tag,
     dsl_dataset_t **dsp)
 {
 	return (dsl_dataset_hold_obj_flags(dp, dsobj, 0, tag, dsp));
@@ -1000,7 +1000,7 @@ skip:
 
 /* dsl_dataset_sendrecv_cancel_all callback for dsl_dataset_active_foreach. */
 static int
-dsl_dataset_sendrecv_cancel_cb(dsl_dataset_t *ds, void *arg)
+dsl_dataset_sendrecv_cancel_cb(dsl_dataset_t *ds, __maybe_unused void *arg)
 {
 	int err;
 

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -678,6 +678,7 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 	dsl_dataset_t *ds;
 	objset_t *mos = dp->dp_meta_objset;
 	list_t synced_datasets;
+	int error;
 
 	list_create(&synced_datasets, sizeof (dsl_dataset_t),
 	    offsetof(dsl_dataset_t, ds_synced_link));
@@ -715,7 +716,8 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 		list_insert_tail(&synced_datasets, ds);
 		dsl_dataset_sync(ds, zio, tx);
 	}
-	VERIFY0(zio_wait(zio));
+	error = zio_wait(zio);
+	VERIFY(error == 0 || (spa_exiting_any(zio->io_spa) && error == EIO));
 
 	/*
 	 * Update the long range free counter after

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -563,7 +563,7 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 }
 
 static int
-spa_config_update_begin(spa_t *spa, void *tag)
+spa_config_update_begin(spa_t *spa, const void *tag)
 {
 
 	return (spa_config_enter_flags(spa, SCL_ALL, tag, RW_WRITER,
@@ -573,7 +573,7 @@ spa_config_update_begin(spa_t *spa, void *tag)
 /* Complete a label update. */
 static int
 spa_config_update_complete(spa_t *spa, uint64_t txg, boolean_t postsysevent,
-    void *tag)
+    const void *tag)
 {
 	int error = 0;
 

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -880,6 +880,9 @@ spa_sync_close_syncing_log_sm(spa_t *spa)
 	sls->sls_nblocks = space_map_nblocks(spa_syncing_log_sm(spa));
 	spa->spa_unflushed_stats.sus_nblocks += sls->sls_nblocks;
 
+	if (sls->sls_nblocks == 0 && spa_exiting(spa))
+		return;
+
 	/*
 	 * Note that we can't assert that sls_mscount is not 0,
 	 * because there is the case where the first metaslab
@@ -918,7 +921,9 @@ spa_cleanup_old_sm_logs(spa_t *spa, dmu_tx_t *tx)
 		ASSERT(avl_is_empty(&spa->spa_sm_logs_by_txg));
 		return;
 	}
-	VERIFY0(error);
+	VERIFY(error == 0 || spa_exiting_any(spa));
+	if (error != 0)
+		return;
 
 	metaslab_t *oldest = avl_first(&spa->spa_metaslabs_by_flushed);
 	uint64_t oldest_flushed_txg = metaslab_unflushed_txg(oldest);
@@ -975,9 +980,9 @@ spa_generate_syncing_log_sm(spa_t *spa, dmu_tx_t *tx)
 		    &spacemap_zap, tx));
 		spa_feature_incr(spa, SPA_FEATURE_LOG_SPACEMAP, tx);
 	}
-	if (error && spa_exiting_any(spa))
+	VERIFY(error == 0 || spa_exiting_any(spa));
+	if (error != 0)
 		return;
-	VERIFY0(error);
 
 	uint64_t sm_obj;
 	ASSERT3U(zap_lookup_int_key(mos, spacemap_zap, txg, &sm_obj),

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -6964,7 +6964,7 @@ zfs_ioctl_register(const char *name, zfs_ioc_t ioc, zfs_ioc_func_t *func,
 	vec->zvec_nvl_key_count = num_keys;
 }
 
-static void
+void
 zfs_ioctl_register_pool(zfs_ioc_t ioc, zfs_ioc_legacy_func_t *func,
     zfs_secpolicy_func_t *secpolicy, boolean_t log_history,
     zfs_ioc_poolcheck_t pool_check)

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -56,6 +56,8 @@ export SYSTEM_FILES_COMMON='arp
     mkdir
     mkfifo
     mknod
+    mkfifo
+    mknod
     mktemp
     mount
     mv

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_follow.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_events/zpool_events_follow.ksh
@@ -54,7 +54,7 @@ log_must zpool clear $TESTPOOL
 zpool_events_settle
 
 # 4. Verify 'zpool events -f' successfully recorded these new events
-EVENTS_LOG=$(cat $EVENTS_FILE | wc -l)
+EVENTS_LOG=$(wc -l < $EVENTS_FILE)
 log_must test $EVENTS_LOG -gt 0
 
 log_pass "'zpool events -f' successfully follows new events."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_expand/zpool_expand_005_pos.ksh
@@ -88,6 +88,7 @@ fi
 
 # online the device so the zpool will use the new space
 log_must zpool online -e $TESTPOOL1 $SDISK
+log_must zpool sync $TESTPOOL1
 
 typeset new_size=$(get_pool_prop size $TESTPOOL1)
 log_note "new pool size: $new_size"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export.kshlib
@@ -25,6 +25,12 @@
 
 . $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.cfg
 
+function create_fifo
+{
+	log_must rm -f $1
+	log_must mkfifo $1
+}
+
 function zpool_export_cleanup
 {
 	[[ -d $TESTDIR0 ]] && log_must rm -rf $TESTDIR0

--- a/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_lun_expsz.ksh
+++ b/tests/zfs-tests/tests/functional/pool_checkpoint/checkpoint_lun_expsz.ksh
@@ -47,8 +47,9 @@ log_must zpool checkpoint $NESTEDPOOL
 
 log_must truncate -s $EXPSZ $FILEDISK1
 log_must zpool online -e $NESTEDPOOL $FILEDISK1
-NEWSZ=$(zpool list -v | grep "$FILEDISK1" | awk '{print $2}')
-DEXPSZ=$(zpool list -v | grep "$FILEDISK1" | awk '{print $6}')
+log_must zpool sync $NESTEDPOOL
+NEWSZ=$(zpool list -v | awk -v d="$FILEDISK1" '$0 ~ d {print $2}')
+DEXPSZ=$(zpool list -v | awk -v d="$FILEDISK1" '$0 ~ d {print $6}')
 nested_change_state_after_checkpoint
 log_mustnot [ "$INITSZ" = "$NEWSZ" ]
 log_must [ "$DEXPSZ" = "-" ]


### PR DESCRIPTION
Here's the updated forced export patch with some extra fixes.

PS The previous PR (#1) was incorrect. 

-----

This is primarily of use when a pool has lost its disk, while the user doesn't care about any pending (or otherwise) transactions.

Implement various control methods to make this feasible:
- txg_wait can now take a NOSUSPEND flag, in which case the caller will be alerted if their txg can't be committed.  This is primarily of interest for callers that would normally pass TXG_WAIT, but don't want to wait if the pool becomes suspended, which allows unwinding in some cases, specifically when one is attempting a non-forced export. Without this, the non-forced export would preclude a forced export by virtue of holding the namespace lock indefinitely.
- txg_wait also returns failure for TXG_WAIT users if a pool is actually being force exported.  Adjust most callers to tolerate this.
- spa_config_enter_flags now takes a NOSUSPEND flag to the same effect.
- DMU objset initiator which may be set on an objset being forcibly exported / unmounted.
- SPA export initiator may be set on a pool being forcibly exported.
- DMU send/recv now use an interruption mechanism which relies on the SPA export initiator being able to enumerate datasets and closing any send/recv streams, causing their EINTR paths to be invoked.
- ZIO now has a cancel entry point, which tells all suspended zios to fail, and which suppresses the failures for non-CANFAIL users.
- metaslab, etc. cleanup, which consists of simply throwing away any changes that were not able to be synced out.
- Linux specific: introduce a new tunable, zfs_forced_export_unmount_enabled, which allows the filesystem to remain in a modified 'unmounted' state upon exiting zpl_umount_begin, to achieve parity with FreeBSD and illumos, which have VFS-level support for yanking filesystems out from under users.  However, this only helps when the user is actively performing I/O, while not sitting on the filesystem.  In particular, this allows test #3 below to pass on Linux.
- Add basic logic to zpool to indicate a force-exporting pool, instead of crashing due to lack of config, etc.

Add tests which cover the basic use cases:
- Force export while a send is in progress
- Force export while a recv is in progress
- Force export while POSIX I/O is in progress

This change modifies the libzfs ABI:
- New ZPOOL_STATUS_FORCE_EXPORTING zpool_status_t enum value.
- New field libzfs_force_export for libzfs_handle.



Sponsored-by: Klara, Inc.
Sponsored-by: Catalogics, Inc.
Sponsored-by: Wasabi Technology, Inc.
Closes #3461
